### PR TITLE
Add 1 as key in size_map. Fix #197.

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -562,6 +562,7 @@ def get_bounty_image(request, id):
         4: 525,
         3: 530,
         2: 533,
+        1: 533
     }
     img = Image.open("coderbounty/static/images/layout/github-poster.png")
     draw = ImageDraw.Draw(img)


### PR DESCRIPTION
Added 1 as key in `size_map`.
Missing key was responsible for `KeyError: 1`.